### PR TITLE
Link against compiler-rt for clang

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -19,6 +19,10 @@ class M4Conan(ConanFile):
     def _is_msvc(self):
         return self.settings.compiler == "Visual Studio"
 
+    @property
+    def _is_clang(self):
+        return str(self.settings.compiler).endswith("clang")
+
     def build_requirements(self):
         if tools.os_info.is_windows:
             self.build_requires("msys2/20161025")
@@ -51,6 +55,9 @@ class M4Conan(ConanFile):
                                  'STRIP=:',
                                  'AR=$PWD/build-aux/ar-lib lib',
                                  'RANLIB=:'])
+                elif self._is_clang:
+                    args.extend(['CFLAGS=-rtlib=compiler-rt'])
+
                 env_build = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
                 env_build.configure(args=args)
                 env_build.make()


### PR DESCRIPTION
Specify library name and version:  **m4/1.4.18**

This fixes an issue where m4 fails to build with clang due to symbols generated by clang but not present in libgcc. See [M4 Bugreport](https://lists.gnu.org/archive/html/bug-m4/2017-07/msg00003.html) and [LLVM Bugreport](https://bugs.llvm.org/show_bug.cgi?id=16404) for details.

The solution is to add the `-rtlib=compiler-rt` flag to `CFLAGS` when compiling with clang.


