### PR TITLE
m4: fix test + cache autotools + run m4 self tests

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -77,6 +77,10 @@ class M4Conan(ConanFile):
         with self._build_context():
             autotools = self._configure_autotools()
             autotools.make()
+            if bool(os.environ.get("CONAN_RUN_TESTS", "")):
+                self.output.info("Running m4 checks...")
+                with tools.chdir("checks"):
+                    autotools.make(target="check-local")
 
     def package(self):
         with self._build_context():

--- a/recipes/m4/all/test_package/conanfile.py
+++ b/recipes/m4/all/test_package/conanfile.py
@@ -7,8 +7,8 @@ class TestPackageConan(ConanFile):
     def build(self):
         test_file = os.path.join(self.source_folder, "test_package.m4")
         in_file = os.path.join(self.build_folder, "input.m4")
-        with open(in_file, "w") as f_in_file, open(test_file, "r") as f_test_file:
-            f_in_file.write(f_test_file.read().replace("\r\n", "\r"))
+        with open(in_file, "wb") as f_in_file, open(test_file, "rb") as f_test_file:
+            f_in_file.write(f_test_file.read().replace(b"\r\n", b"\n"))
         assert "\r\n" not in open(in_file, "r")
 
         self.run("{} --version".format(os.environ["M4"]))
@@ -16,5 +16,5 @@ class TestPackageConan(ConanFile):
         self.run("{} -P {} > out".format(os.environ["M4"], in_file))
 
     def test(self):
-        if "\r\n" in open("out", "rb"):
+        if b"\r\n" in open("out", "rb"):
             raise Exception("m4 output has DOS line-endings!")


### PR DESCRIPTION
@SSE4 

- cache autotools
- fix my text/binary screw-up in test_package
- run m4 unittests if the environment variable `CONAN_RUN_TESTS` is defined

These unit tests run on Linux, they fail on Windows.

Specify library name and version:  **m4/1.4.18**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

