### PR TITLE
gperf: add support for mingw on Linux

### DIFF
--- a/recipes/gperf/all/test_package/conanfile.py
+++ b/recipes/gperf/all/test_package/conanfile.py
@@ -3,6 +3,9 @@ from conans import ConanFile, tools
 
 class TestPackageConan(ConanFile):
 
+    settings = "arch_build", "os_build"
+
     def test(self):
+        bin_ext = ".exe" if self.settings.os_build == "Windows" else ""
         if not tools.cross_building(self.settings):
-            self.run("gperf --version")
+            self.run("gperf{} --version".format(bin_ext))


### PR DESCRIPTION
Specify library name and version:  **gperf/3.1**

conan-io/conan-center-index#785

@Croydon 

This allows building gperf on Linux using gperf, using this profile:
```
[settings]
os=Windows
os_build=Windows
arch=x86_64
arch_build=x86_64
compiler=gcc
compiler.version=8
compiler.libcxx=libstdc++11
compiler.threads=win32
compiler.exception=seh
build_type=Release
[options]
[build_requires]
[env]
CC=x86_64-w64-mingw32-gcc
CXX=x86_64-w64-mingw32-g++
RC=x86_64-w64-mingw32-windres

```

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

