### PR TITLE
Fix compilation for non-lite version

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -70,9 +70,12 @@ class ProtobufConan(ConanFile):
             self._cmake.configure(build_folder=self._build_subfolder)
         return self._cmake
 
-    def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
+    def _patch_sources(self):
+        if "patches" in self.conan_data:
+            if self.version in self.conan_data["patches"]:
+                for patch in self.conan_data.get("patches", {}).get(self.version, []):
+                    tools.patch(**patch)
+
         tools.replace_in_file(
             os.path.join(self._source_subfolder, "cmake", "protobuf-config.cmake.in"),
             "@_protobuf_FIND_ZLIB@",
@@ -116,6 +119,8 @@ if(DEFINED Protobuf_SRC_ROOT_FOLDER)""",
             'endif()',
         )
 
+    def build(self):
+        self._patch_sources()
         cmake = self._configure_cmake()
         cmake.build()
 

--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -71,10 +71,8 @@ class ProtobufConan(ConanFile):
         return self._cmake
 
     def _patch_sources(self):
-        if "patches" in self.conan_data:
-            if self.version in self.conan_data["patches"]:
-                for patch in self.conan_data.get("patches", {}).get(self.version, []):
-                    tools.patch(**patch)
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
 
         tools.replace_in_file(
             os.path.join(self._source_subfolder, "cmake", "protobuf-config.cmake.in"),

--- a/recipes/protobuf/all/test_package/CMakeLists.txt
+++ b/recipes/protobuf/all/test_package/CMakeLists.txt
@@ -2,35 +2,17 @@ cmake_minimum_required(VERSION 3.1)
 project(test_package)
 
 include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-conan_basic_setup()
+conan_basic_setup(TARGETS)
+
+find_package(Protobuf CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp addressbook.proto)
-target_link_libraries(${PROJECT_NAME} ${CONAN_LIBS})
+target_link_libraries(${PROJECT_NAME} protobuf::libprotobuf protobuf::libprotoc) # if protobuf is compiled as 'lite' this will fail
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_BINARY_DIR}")
 
-find_package(Protobuf REQUIRED)
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS TARGET ${PROJECT_NAME})
-
-message(STATUS "PROTO_SRCS: ${PROTO_SRCS}")
-message(STATUS "PROTO_HDRS: ${PROTO_HDRS}")
-
-## TODO: rough draft if targets and variables have the correct casing:
-# conan_basic_setup(TARGETS)
-
-# find_package(Protobuf CONFIG REQUIRED)
-
-# add_executable(${PROJECT_NAME} test_package.cpp)
-# target_link_libraries(${PROJECT_NAME} protobuf::libprotobuf protobuf::libprotoc)
-# set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
-# target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_BINARY_DIR}")
-
-# # protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS TARGET ${PROJECT_NAME})
-
-# protobuf_generate(
-#  LANGUAGE cpp
-#  TARGET ${PROJECT_NAME}
-#  PROTOS addressbook.proto)
+protobuf_generate(LANGUAGE cpp TARGET ${PROJECT_NAME} PROTOS addressbook.proto)
 
 # # message(STATUS "PROTO_SRCS: ${PROTO_SRCS}")
 # # message(STATUS "PROTO_HDRS: ${PROTO_HDRS}")

--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -9,7 +9,6 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        #cmake.definitions["protobuf_LITE"] = self.options["protobuf"].lite
         cmake.configure()
         cmake.build()
 

--- a/recipes/protobuf/all/test_package/conanfile.py
+++ b/recipes/protobuf/all/test_package/conanfile.py
@@ -9,8 +9,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.definitions["protobuf_VERBOSE"] = True
-        cmake.definitions["protobuf_MODULE_COMPATIBLE"] = True
+        #cmake.definitions["protobuf_LITE"] = self.options["protobuf"].lite
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Please consider these changes.
I've tried with v3.9.1, v3.11.4, v3.12.4 with default options and seems to work in my machine (macos)

/cc @uilianries 