### PR TITLE
Support for Folly 2022.01.31.00

### DIFF
--- a/recipes/folly/all/conandata.yml
+++ b/recipes/folly/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "2020.08.10.00":
     url: "https://github.com/facebook/folly/archive/v2020.08.10.00.tar.gz"
     sha256: "e81140d04a4e89e3f848e528466a9b3d3ae37d7eeb9e65467fca50d70918eef6"
-  "2021.07.20.01":
-    url: "https://github.com/facebook/folly/archive/v2021.07.20.01.tar.gz"
-    sha256: "3b6ff97ee56699362bd22579b7d01697323f7fc2b6d37477e3e542f52857e0e8"
   "2022.01.31.00":
     url: "https://github.com/facebook/folly/archive/v2022.01.31.00.tar.gz"
     sha256: "d764b9a7832d967bb7cfea4bcda15d650315aa4d559fde1da2a52b015cd88b9c"
@@ -45,17 +42,6 @@ patches:
     - patch_file: "patches/0014-find-librt.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0015-benchmark-format-macros.patch"
-      base_path: "source_subfolder"
-  "2021.07.20.01":
-    - patch_file: "patches/0016-find-packages.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0017-compiler-flags.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0018-find-glog.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0019-exclude-example.patch"
-      base_path: "source_subfolder"
-    - patch_file: "patches/0021-typedef-clockid.patch"
       base_path: "source_subfolder"
   "2022.01.31.00":
     - patch_file: "patches/0016-find-packages.patch"

--- a/recipes/folly/all/conandata.yml
+++ b/recipes/folly/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "2021.07.20.01":
     url: "https://github.com/facebook/folly/archive/v2021.07.20.01.tar.gz"
     sha256: "3b6ff97ee56699362bd22579b7d01697323f7fc2b6d37477e3e542f52857e0e8"
+  "2022.01.31.00":
+    url: "https://github.com/facebook/folly/archive/v2022.01.31.00.tar.gz"
+    sha256: "d764b9a7832d967bb7cfea4bcda15d650315aa4d559fde1da2a52b015cd88b9c"
 patches:
   "2019.10.21.00":
     - patch_file: "patches/0001-find-packages.patch"
@@ -53,4 +56,15 @@ patches:
     - patch_file: "patches/0019-exclude-example.patch"
       base_path: "source_subfolder"
     - patch_file: "patches/0021-typedef-clockid.patch"
+      base_path: "source_subfolder"
+  "2022.01.31.00":
+    - patch_file: "patches/0016-find-packages.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0017-compiler-flags.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0018-find-glog.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0019-exclude-example.patch"
+      base_path: "source_subfolder"
+    - patch_file: "patches/0022-fix-windows-minmax.patch"
       base_path: "source_subfolder"

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -112,10 +112,6 @@ class FollyConan(ConanFile):
         if miss_boost_required_comp:
             raise ConanInvalidConfiguration("Folly requires these boost components: {}".format(", ".join(self._required_boost_components)))
 
-        # FIXME: https://github.com/facebook/folly/issues/1655
-        if self.settings.compiler == "apple-clang" and tools.Version(self.settings.compiler.version) >= "12.0":
-            raise ConanInvalidConfiguration("Apple Clang 12 can not deal with ___cxa_increment_exception_refcount")
-
     def _configure_cmake(self):
         if not self._cmake:
             self._cmake = CMake(self)
@@ -206,3 +202,6 @@ class FollyConan(ConanFile):
            (self.settings.os == "Macos" and self.settings.compiler == "apple-clang" and
             Version(self.settings.compiler.version.value) == "9.0" and self.settings.compiler.libcxx == "libc++"):
             self.cpp_info.components["libfolly"].system_libs.append("atomic")
+
+        if self.settings.os == "Macos" and self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version.value) >= "12.0":
+            self.cpp_info.components["libfolly"].system_libs.append("c++abi")

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -28,7 +28,7 @@ class FollyConan(ConanFile):
 
     @property
     def _minimum_cpp_standard(self):
-        return 17 if tools.Version(self.version) >= "2021.07.20.00" else 14
+        return 17 if tools.Version(self.version) >= "2022.01.31.00" else 14
 
     @property
     def _minimum_compilers_version(self):

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -66,7 +66,7 @@ class FollyConan(ConanFile):
         self.requires("gflags/2.2.2")
         self.requires("glog/0.4.0")
         self.requires("libevent/2.1.12")
-        self.requires("openssl/1.1.1l")
+        self.requires("openssl/1.1.1m")
         self.requires("lz4/1.9.3")
         self.requires("snappy/1.1.8")
         self.requires("zlib/1.2.11")

--- a/recipes/folly/all/patches/0022-fix-windows-minmax.patch
+++ b/recipes/folly/all/patches/0022-fix-windows-minmax.patch
@@ -1,0 +1,12 @@
+diff --git a/CMake/FollyCompilerMSVC.cmake b/CMake/FollyCompilerMSVC.cmake
+index ec2ce1a1d..16deda71c 100644
+--- a/CMake/FollyCompilerMSVC.cmake
++++ b/CMake/FollyCompilerMSVC.cmake
+@@ -289,6 +289,7 @@ function(apply_folly_compile_options_to_target THETARGET)
+   # And the extra defines:
+   target_compile_definitions(${THETARGET}
+     PUBLIC
++      NOMINMAX
+       _CRT_NONSTDC_NO_WARNINGS # Don't deprecate posix names of functions.
+       _CRT_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
+       _SCL_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.


### PR DESCRIPTION
Specify library name and version:  **folly/2022.01.31.00**

Adds support for Folly v2022.01.31.00.  This is the version that vcpkg is at currently.  

In addition:
- Removed 2021.07.20.01 
- Updated requirement to openssl/1.1.1m to resolve conflict with libevent
- Add minmax patch for Windows builds
- Link to c++abi on Apple Clang 12+ to avoid ___cxa_increment_exception_refcount error

Built on the following:
- Linux gcc8 and gcc9
- Linux Clang 10
- Windows VS2019 MD and MT
- MacOS Apple Clang 12

---

- [X] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [X] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [X] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [X] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
