### PR TITLE
Jasper: several fixes

### DIFF
--- a/recipes/jasper/all/conandata.yml
+++ b/recipes/jasper/all/conandata.yml
@@ -14,6 +14,9 @@ patches:
     - patch_file: "patches/3.0.6-0002-find-libjpeg.patch"
       patch_description: "check_c_source_compilers does not work with conan gens. See https://github.com/conan-io/conan/issues/12180"
       patch_type: "conan"
+    - patch_file: "patches/3.0.6-0003-deterministic-libname.patch"
+      patch_description: "No generator dependent libname"
+      patch_type: "conan"
   "2.0.33":
     - patch_file: "patches/2.0.33-0001-skip-rpath.patch"
       patch_description: "Do not enforce rpath configuration"

--- a/recipes/jasper/all/patches/3.0.6-0003-deterministic-libname.patch
+++ b/recipes/jasper/all/patches/3.0.6-0003-deterministic-libname.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -254,7 +254,7 @@ endif()
+ # If a multiconfiguration generator is used, ensure that various output
+ # files are not placed in subdirectories (such as Debug and Release)
+ # as this will cause the CTest test suite to fail.
+-if(JAS_MULTICONFIGURATION_GENERATOR)
++if(0)
+ 	if(CMAKE_CONFIGURATION_TYPES)
+ 		set(CMAKE_DEBUG_POSTFIX d)
+ 	endif()

--- a/recipes/jasper/all/test_package/CMakeLists.txt
+++ b/recipes/jasper/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
-project(test_package C)
+project(test_package LANGUAGES C)
 
-find_package(Jasper REQUIRED CONFIG)
+find_package(Jasper REQUIRED)
 
 set(_custom_vars
     JASPER_FOUND

--- a/recipes/jasper/all/test_package/conanfile.py
+++ b/recipes/jasper/all/test_package/conanfile.py
@@ -9,11 +9,11 @@ class TestPackageConan(ConanFile):
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"
 
-    def requirements(self):
-        self.requires(self.tested_reference_str)
-
     def layout(self):
         cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/jasper/all/test_v1_package/conanfile.py
+++ b/recipes/jasper/all/test_v1_package/conanfile.py
@@ -3,8 +3,8 @@ import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
- restore cmake_find_mode both, it must not be removed
- deterministic lib name in 3.x (no debug postfix if multi config generator)
- remove useless VirtualBuildEnv (no tool_requires)
- always define `set(JASPER_FOUND TRUE)` in CMakeDeps

---

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
